### PR TITLE
Update: Minor modifies for reproducing from scratch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,12 +18,21 @@
     SIGHAN15_CSC_TestTruth.txt
     ```
 
+## 环境准备
+1. 使用已有编码环境或通过 `conda create -n <your_env_name> python=3.7` 创建一个新环境（推荐）
+2. 克隆本项目并进入项目根目录 
+3. 安装所需依赖 `pip install -r requirements.txt`
+4. 如果出现报错 GLIBC 版本过低的问题（GLIBC 的版本更迭容易出事故，不推荐更新），openCC 改为安装较低版本（例如 1.1.0）
+5. 在当前终端将此目录加入环境变量 `export PYTHONPATH=.`
+
+
 ## 训练
 
 运行以下命令以训练模型，首次运行会自动处理数据。
 ```shell
 python tools/train_csc.py --config_file csc/train_SoftMaskedBert.yml
 ```
+
 可选择不同配置文件以训练不同模型，目前支持以下配置文件：
 - train_bert4csc.yml
 - train_macbert4csc.yml

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 
 运行以下命令以训练模型，首次运行会自动处理数据。
 ```shell
-python tools/train_csc.py --config_file train_SoftMaskedBert.yml
+python tools/train_csc.py --config_file csc/train_SoftMaskedBert.yml
 ```
 可选择不同配置文件以训练不同模型，目前支持以下配置文件：
 - train_bert4csc.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tokenizers==0.9.4
 torch==1.6.0
 transformers==4.1.1
 yacs
+lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-OpenCC==1.1.1
+OpenCC>=1.1.0,<=1.1.1
 pytorch-lightning==1.1.2
 six==1.14.0
 tensorboard==2.4.0


### PR DESCRIPTION
+ Update missing package `lxml` in requirements for new environments. 
+ Update allowed lower version for `openCC` and descriptions in `readme`, for how to deal with the issue about `openCC` / `GLIBC` versions.
+ Fix faulty path in commands for training.
+ Now people (at least @okcd00) can follow the `readme.md` all the way to the training stage in a new environment. 