### PR TITLE
Fix: A faulty var name in `pl.Trainer`.

### DIFF
--- a/tools/bases.py
+++ b/tools/bases.py
@@ -68,7 +68,7 @@ def train(config, model, loaders, ckpt_callback=None):
     trainer = pl.Trainer(max_epochs=config.SOLVER.MAX_EPOCHS,
                          gpus=None if config.MODEL.DEVICE == 'cpu' else config.MODEL.GPU_IDS,
                          accumulate_grad_batches=config.SOLVER.ACCUMULATE_GRAD_BATCHES,
-                         checkpoint_callback=ckpt_callback)
+                         callbacks=[ckpt_callback])
     # 满足以下条件才进行训练
     # 1. 配置文件中要求进行训练
     # 2. train_loader不为空

--- a/tools/bases.py
+++ b/tools/bases.py
@@ -68,7 +68,7 @@ def train(config, model, loaders, ckpt_callback=None):
     trainer = pl.Trainer(max_epochs=config.SOLVER.MAX_EPOCHS,
                          gpus=None if config.MODEL.DEVICE == 'cpu' else config.MODEL.GPU_IDS,
                          accumulate_grad_batches=config.SOLVER.ACCUMULATE_GRAD_BATCHES,
-                         callbacks=ckpt_callback)
+                         checkpoint_callback=ckpt_callback)
     # 满足以下条件才进行训练
     # 1. 配置文件中要求进行训练
     # 2. train_loader不为空


### PR DESCRIPTION
This issue from the last commit makes the repo not work now.            
The feeding vars for `callbacks` should be a list, the `ckpt_callback` is an instance of `ModelCheckpoint`.


![image](https://user-images.githubusercontent.com/9395067/123205630-d7091880-d4ec-11eb-8d64-8710277fd293.png)
