### PR TITLE
Allow loading the model directly without argsParser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ python inference.py --ckpt_fn epoch=0-val_loss=0.03.ckpt --text_file /ml/data/te
 ```
 ### 方法二，直接调用
 ```python
+from tools.inference import *
+ckpt_fn = 'SoftMaskedBert/epoch=02-val_loss=0.02904.ckpt'  # find it in checkpoints/
+config_file = 'csc/train_SoftMaskedBert.yml'  # find it in configs/
+model = load_model_directly(ckpt_fn=ckpt_fn, config_file=config_file)
 texts = ['今天我很高心', '测试', '继续测试']
 model.predict(texts)
 ```

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -34,6 +34,29 @@ def parse_args():
     return args
 
 
+def load_model_directly(ckpt_file, config_file):
+    # Example:
+    # ckpt_fn = 'SoftMaskedBert/epoch=02-val_loss=0.02904.ckpt' (find in checkpoints)
+    # config_file = 'csc/train_SoftMaskedBert.yml' (find in configs)
+    
+    from bbcm.config import cfg
+    cp = get_abs_path('checkpoints', ckpt_file)
+    cfg.merge_from_file(get_abs_path('configs', config_file))
+    tokenizer = BertTokenizer.from_pretrained(cfg.MODEL.BERT_CKPT)
+
+    if cfg.MODEL.NAME in ['bert4csc', 'macbert4csc']:
+        model = BertForCsc.load_from_checkpoint(cp,
+                                                cfg=cfg,
+                                                tokenizer=tokenizer)
+    else:
+        model = SoftMaskedBertModel.load_from_checkpoint(cp,
+                                                         cfg=cfg,
+                                                         tokenizer=tokenizer)
+    model.eval()
+    model.to(cfg.MODEL.DEVICE)
+    return model
+
+
 def load_model(args):
     from bbcm.config import cfg
     cfg.merge_from_file(get_abs_path('configs', args.config_file))


### PR DESCRIPTION
People sometimes need to load the model in Jupyter or for downstream applications, without argsParser.         
It is also used for showing a better way to use the model, in `README.md`.      
It might be a good feature for researchers.


![image](https://user-images.githubusercontent.com/9395067/123788786-ff3eb000-d90e-11eb-8ef6-b2e33dad7a4d.png)
