### PR TITLE
truncate the input exceeds model_max_length

### DIFF
--- a/bbcm/modeling/csc/modeling_bert4csc.py
+++ b/bbcm/modeling/csc/modeling_bert4csc.py
@@ -23,12 +23,12 @@ class BertForCsc(CscTrainingModel):
 
     def forward(self, texts, cor_labels=None, det_labels=None):
         if cor_labels is not None:
-            text_labels = self.tokenizer(cor_labels, padding=True, return_tensors='pt')['input_ids']
+            text_labels = self.tokenizer(cor_labels, padding=True, return_tensors='pt', truncation=True)['input_ids']
             text_labels = text_labels.to(self.device)
             text_labels[text_labels == 0] = -100
         else:
             text_labels = None
-        encoded_text = self.tokenizer(texts, padding=True, return_tensors='pt')
+        encoded_text = self.tokenizer(texts, padding=True, return_tensors='pt', truncation=True)
         encoded_text.to(self.device)
         bert_outputs = self.bert(**encoded_text, labels=text_labels, return_dict=True, output_hidden_states=True)
         # 检错概率

--- a/bbcm/modeling/csc/modeling_soft_masked_bert.py
+++ b/bbcm/modeling/csc/modeling_soft_masked_bert.py
@@ -54,13 +54,13 @@ class BertCorrectionModel(torch.nn.Module, ModuleUtilsMixin):
 
     def forward(self, texts, prob, embed=None, cor_labels=None, residual_connection=False):
         if cor_labels is not None:
-            text_labels = self.tokenizer(cor_labels, padding=True, return_tensors='pt')['input_ids']
+            text_labels = self.tokenizer(cor_labels, padding=True, return_tensors='pt', truncation=True)['input_ids']
             text_labels = text_labels.to(self._device)
             # torch的cross entropy loss 会忽略-100的label
             text_labels[text_labels == 0] = -100
         else:
             text_labels = None
-        encoded_texts = self.tokenizer(texts, padding=True, return_tensors='pt')
+        encoded_texts = self.tokenizer(texts, padding=True, return_tensors='pt', truncation=True)
         encoded_texts.to(self._device)
         if embed is None:
             embed = self.embeddings(input_ids=encoded_texts['input_ids'],
@@ -127,7 +127,7 @@ class SoftMaskedBertModel(CscTrainingModel):
         self._device = cfg.MODEL.DEVICE
 
     def forward(self, texts, cor_labels=None, det_labels=None):
-        encoded_texts = self.tokenizer(texts, padding=True, return_tensors='pt')
+        encoded_texts = self.tokenizer(texts, padding=True, return_tensors='pt', truncation=True)
         encoded_texts.to(self._device)
         embed = self.corrector.embeddings(input_ids=encoded_texts['input_ids'],
                                           token_type_ids=encoded_texts['token_type_ids'])


### PR DESCRIPTION
Fix error when input exceeds the model_max_length

Traceback (most recent call last):
  File "/root/SoftMaskedBert.py", line 38, in <module>
    raise e
  File "/root/SoftMaskedBert.py", line 34, in <module>
    result = model.predict(texts)[0].strip()
  File "/root/BertBasedCorrectionModels/bbcm/engine/csc_trainer.py", line 83, in predict
    outputs = self.forward(texts)
  File "/root/BertBasedCorrectionModels/bbcm/modeling/csc/modeling_soft_masked_bert.py", line 132, in forward
    embed = self.corrector.embeddings(input_ids=encoded_texts['input_ids'],
  File "/root/miniconda3/envs/correction39/lib/python3.9/site-packages/torch/nn/modules/module.py", line 727, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/root/miniconda3/envs/correction39/lib/python3.9/site-packages/transformers/models/bert/modeling_bert.py", line 204, in forward
    embeddings += position_embeddings
RuntimeError: The size of tensor a (2545) must match the size of tensor b (512) at non-singleton dimension 1